### PR TITLE
in_tail: Fix error on setting page for binary file

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -11,7 +11,7 @@ class ApiController < ApplicationController
     unless File.file?(file) && File.readable?(file)
       return render json: [], status: 403
     end
-    render json: file_tail(file) || []
+    render json: file_tail(file)
   end
 
   def empty_json

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -101,10 +101,10 @@ class ApplicationController < ActionController::Base
   end
 
   def file_tail(path, limit = 10)
-    return unless path
-    return unless File.exists? path
+    return [] unless path
+    return [] unless File.exists? path
     reader = FileReverseReader.new(File.open(path))
-    return if reader.binary_file?
+    return [] if reader.binary_file?
     reader.tail(limit)
   end
 end


### PR DESCRIPTION
How to reproduce:
- Create a binary file by the following command:
  
  ```
  "ruby -e 'puts "\u3042"' > /tmp/xxx"
  ```
- Open /daemon/setting/in_tail
- Select "/tmp/xxx"
- Error page is rendered
- log/production.log says:
  
  ```
  ActionView::Template::Error (undefined method `join' for nil:NilClass):
      12:     = f.text_field :path, class: "form-control", disabled: true
      13:   = render partial: "shared/vue/in_tail_format", locals: { file: f.object.path, formats: @setting.known_formats, initialSelected: f.object.format || @setting.guess_format }
      14:
      15:   %pre= file_tail(@setting.path).join("\n")
      16:
      17:   %p
      18:     = f.submit t('terms.next'), class: "btn btn-lg btn-primary pull-right"
    app/views/fluentd/settings/in_tail/after_file_choose.html.haml:15:in `block in _app_views_fluentd_settings_in_tail_after_file_choose_html_haml___1713159989942914940_40548520'
  ```
