### PR TITLE
Remove bcrypt gem for packaging issue on Mac

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Release 0.1.5 - (not released yet)
 
 * [fixed] Keep changed password after update fluentd-ui gem.
 * [fixed] Add missing LICENSE file (Apache license 2.0)
+* [change] Remove bcrypt for packaging issue on Mac.
 
 Release 0.1.4 - 2014/08/20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,8 @@
 PATH
   remote: .
   specs:
-    fluentd-ui (0.1.3)
+    fluentd-ui (0.1.4)
       addressable
-      bcrypt (~> 3.1.5)
       bundler
       fluentd (~> 0.10.51)
       font-awesome-rails
@@ -52,7 +51,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.6)
     arel (5.0.1.20140414130214)
-    bcrypt (3.1.7)
     builder (3.2.2)
     capybara (2.2.1)
       mime-types (>= 1.16)
@@ -145,7 +143,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    puma (2.8.2)
+    puma (2.9.0)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
     rack-test (0.6.2)

--- a/fluentd-ui.gemspec
+++ b/fluentd-ui.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "fluentd", "~> 0.10.51"
   spec.add_dependency 'rails', '4.1.4'
   spec.add_dependency 'sucker_punch', "~> 1.0.5"
-  spec.add_dependency 'bcrypt', '~> 3.1.5'
   spec.add_dependency 'addressable'
   spec.add_dependency "font-awesome-rails"
   spec.add_dependency 'sass-rails', '~> 4.0.3'


### PR DESCRIPTION
Using SHA1 + stretching instead of bcrypt thus authentication process is now purely Ruby.
