### PR TITLE
Cleanly exits from commands.

### DIFF
--- a/lib/fluentd-ui/command.rb
+++ b/lib/fluentd-ui/command.rb
@@ -8,6 +8,7 @@ module FluentdUI
     option :pidfile, type: :string, default: File.expand_path('tmp/fluentd-ui.pid', ROOT)
     option :daemonize, type: :boolean, default: false
     def start
+      trap(:INT) { puts "\nStopping..." }
       system(*%W(bundle exec rackup #{options[:daemonize] ? "-D" : ""} --pid #{options[:pidfile]} -p #{options[:port]} -E production #{ROOT}/config.ru))
     end
 
@@ -40,6 +41,7 @@ module FluentdUI
       install dependency gems
     DESC
     def setup
+      trap(:INT) { puts "\nStopping..." }
       system(*%W(bundle install))
     end
 


### PR DESCRIPTION
I use ctrl+c and get this when running the `start` or `setup` commands

``` bash
^C/Users/kyuden/pj/pr/fluentd-ui/lib/fluentd-ui/command.rb:11:in `system': Interrupt
        from /Users/kyuden/pj/pr/fluentd-ui/lib/fluentd-ui/command.rb:11:in `start'
        from /Users/kyuden/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
        from /Users/kyuden/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
        from /Users/kyuden/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
        from /Users/kyuden/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
        from /Users/kyuden/pj/pr/fluentd-ui/bin/fluentd-ui:13:in `<top (required)>'
        from /Users/kyuden/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bin/fluentd-ui:23:in `load'
        from /Users/kyuden/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/bin/fluentd-ui:23:in `<main>'
```

This captures interrupts(ctrl + c) when running the commands and  lets them close cleanly without printing the exception to the terminal.

Documentation on the Interrupt exception said that it is normally rescued using Signal#trap.  http://www.ruby-doc.org/core-2.1.1/Interrupt.html
