### PR TITLE
Hide processing plugins not to uninstall.

### DIFF
--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -4,7 +4,7 @@ class PluginsController < ApplicationController
   end
 
   def installed
-    @plugins = Plugin.installed
+    @plugins = Plugin.installed.reject{|plugin| plugin.processing? }
   end
 
   def recommended


### PR DESCRIPTION
Processing plugins shouldn't be listed as installed plugins because they might be in the process of installing or uninstalling.
