### PR TITLE
Add dep:list task to help packaging td-agent-ui

### DIFF
--- a/lib/tasks/dep.rake
+++ b/lib/tasks/dep.rake
@@ -8,10 +8,12 @@ namespace :dep do
     versions = {
       "bundler" => "1.7.4" # bundler version does not appear in Gemfile.lock
     }
+    skip_gems = %w(fluentd)
     lock_file = "Gemfile.production.lock"
     unless ENV["SKIP_BUNDLE_INSTALL"]
       system("bundle install --gemfile Gemfile.production", out: STDERR) # ensure lock file is up to date
     end
+
     File.open(lock_file).each_line do |line|
       # GEM
       #   remote: https://rubygems.org/
@@ -29,10 +31,16 @@ namespace :dep do
       end
       gem_name = line[/[^ \n]+/, 0] # "    foo_gem (0.1.2)\n" => "foo_gem"
       if line.match(/^ {4}[^ ]/)    # "    foo_gem (0.1.2)"
+        if skip_gems.include?(gem_name)
+          current_parent = nil
+          next
+        end
         current_parent = gem_name
         versions[current_parent] = line[/\((.*?)\)/, 1] # foobar (1.2.3) => 1.2.3
         next
       elsif line.match(/^ {6}[^ ]/) # "      foo_dep1 (>= 1.0.0)"
+        next if skip_gems.include?(gem_name)
+        next if current_parent.blank?
         deps.add([current_parent, gem_name])
       else
         context = false


### PR DESCRIPTION
``` console
$ bundle exec rake -T | grep dep:list
rake dep:list                           # list dependency gems order by less referenced
$ bundle exec rake dep:list
download "hike", "1.2.3"
download "addressable", "2.3.6"
download "bundler", "1.7.4"
download "sass", "3.2.19"
download "rake", "10.3.2"
download "mime-types", "2.4.3"
download "multi_json", "1.10.1"
download "httpclient", "2.5.3.1"
download "tilt", "1.4.1"
download "yajl-ruby", "1.2.1"
download "kramdown", "1.5.0"
download "sigdump", "0.2.2"
download "msgpack", "0.5.9"
download "http_parser.rb", "0.6.0"
download "rubyzip", "1.1.6"
download "cool.io", "1.2.4"
download "settingslogic", "2.0.9"
download "request_store", "1.1.0"
download "thor", "0.19.1"
download "timers", "1.1.0"
download "thread_safe", "0.3.4"
download "minitest", "5.4.2"
download "json", "1.8.1"
download "i18n", "0.6.11"
download "rack", "1.5.2"
download "arel", "5.0.1.20140414130214"
download "builder", "3.2.2"
download "erubis", "2.7.0"
download "puma", "2.9.2"
download "font-awesome-rails", "4.2.0.0"
download "rack-test", "0.6.2"
download "haml", "4.0.5"
download "mail", "2.6.3"
download "tzinfo-data", "1.2014.9"
download "kramdown-haml", "0.0.3"
download "tzinfo", "1.2.2"
download "celluloid", "0.15.2"
download "sucker_punch", "1.0.5"
download "activemodel", "4.1.7"
download "jbuilder", "2.2.4"
download "jquery-rails", "3.1.2"
download "actionmailer", "4.1.7"
download "sprockets-rails", "2.2.0"
download "actionview", "4.1.7"
download "activerecord", "4.1.7"
download "sass-rails", "4.0.4"
download "draper", "1.4.0"
download "railties", "4.1.7"
download "haml-rails", "0.5.3"
download "sprockets", "2.11.3"
download "actionpack", "4.1.7"
download "activesupport", "4.1.7"
download "fluentd", "0.10.56"
download "rails", "4.1.7"
download "fluentd-ui", "0.3.0"
```

@repeatedly how's that?
