### PR TITLE
Fix to avoid pass Enumerator to Rails.cache.fetch

### DIFF
--- a/app/models/fluent_gem.rb
+++ b/app/models/fluent_gem.rb
@@ -21,7 +21,7 @@ module FluentGem
         if $? && $?.exitstatus != 0 # NOTE: $? will be nil on CircleCI, so check $? at first
           raise GemError, "failed command: `#{gem} list`"
         end
-        output.lines
+        output.lines.to_a
       end
     end
 


### PR DESCRIPTION
when no data exists.

it causes the following error.
``` 
TypeError (no _dump_data is defined for class Enumerator):
  app/models/fluent_gem.rb:19:in `list'
  app/models/plugin.rb:89:in `block in installed'
  app/models/plugin.rb:88:in `installed'
  app/controllers/plugins_controller.rb:7:in `installed'
```