### PR TITLE
Fix flashing regexp (Fix #145)

### DIFF
--- a/app/assets/javascripts/vue/in_tail_format.js
+++ b/app/assets/javascripts/vue/in_tail_format.js
@@ -120,9 +120,12 @@
         },
 
         preview: function(){
+          if(this.previewAjax) {
+            this.previewAjax.abort();
+          }
           var self = this;
           new Promise(function(resolve, reject) {
-            $.ajax({
+            self.previewAjax = $.ajax({
               method: "POST",
               url: "/api/regexp_preview",
               data: {
@@ -137,7 +140,9 @@
             self.regexpMatches = result.matches;
             self.updateHighlightedLines();
           })["catch"](function(error){
-            console.error(error.stack);
+            if(error.stack) {
+              console.error(error.stack);
+            }
           });
         },
       }


### PR DESCRIPTION
Previewing regexp is using Ajax fired by input field changed.
if server-side processing is slow and/or client-side input so fast, multiple Ajax are running.
That causes #145 issue.

This PR fix to avoid multiple requesting at the same time.