### PR TITLE
Fix #157 remove parameters causing warn on fluentd

### DIFF
--- a/app/models/fluentd/setting/out_s3.rb
+++ b/app/models/fluentd/setting/out_s3.rb
@@ -8,7 +8,7 @@ class Fluentd
         :match,
         :aws_key_id, :aws_sec_key, :s3_bucket, :s3_region, :path,
         # :reduced_redundancy, :check_apikey_on_start, :command_parameter, # not configurable?
-        :format, :include_time_key, :time_key, :delimiter, :label_delimiter, :add_newline, :output_tag, :output_time,
+        :format, :include_time_key, :time_key, :delimiter, :label_delimiter,
         :time_slice_format, :time_slice_wait, :time_format, :utc, :store_as, :proxy_uri, :use_ssl,
         :buffer_type, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,
         :retry_wait, :retry_limit, :max_retry_wait, :num_threads,
@@ -19,7 +19,7 @@ class Fluentd
       choice :format, %w(out_file json ltsv single_value)
       choice :store_as, %w(gzip lzo lzma2 json txt)
       choice :buffer_type, %w(memory file)
-      booleans :include_time_key, :add_newline, :use_ssl, :output_tag, :output_time
+      booleans :include_time_key, :use_ssl
       flags :utc
 
       validates :match, presence: true
@@ -28,8 +28,6 @@ class Fluentd
       def self.initial_params
         {
           s3_region: "us-west-1",
-          output_tag: true,
-          output_time: true,
           use_ssl: true,
         }
       end
@@ -43,7 +41,7 @@ class Fluentd
 
       def advanced_options
         [
-          :format, :output_tag, :output_time, :include_time_key, :time_key, :delimiter, :label_delimiter,
+          :format, :include_time_key, :time_key, :delimiter, :label_delimiter,
           :utc, :time_slice_format, :time_slice_wait, :store_as, :proxy_uri,
           :buffer_type, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,
           :retry_wait, :retry_limit, :max_retry_wait, :num_threads,


### PR DESCRIPTION
Remove `add_newline`, `output_tag` and `output_time` from s3 setting then I don't get any warnings with out_s3 0.5.6.

@repeatedly Now, generated config as below. looks good?

```
<match s3.**>
  type s3
  aws_key_id XXXXXXXXXXXXX
  aws_sec_key XXXXXXXX
  s3_bucket bbb
  s3_region us-west-1
  format out_file
  include_time_key false
  store_as gzip
  use_ssl true
  buffer_type memory
</match>
```