### PR TITLE
Fix #158 validation for buffer_path when buffer_type is 'file'

### DIFF
--- a/app/models/fluentd/setting/out_mongo.rb
+++ b/app/models/fluentd/setting/out_mongo.rb
@@ -6,7 +6,7 @@ class Fluentd
       KEYS = [
         :match,
         :host, :port, :database, :collection, :capped, :capped_size, :capped_max, :user, :password, :tag_mapped,
-        :buffer_type, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,  :retry_wait, :retry_limit, :max_retry_wait, :num_threads,
+        :buffer_type, :buffer_path, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,  :retry_wait, :retry_limit, :max_retry_wait, :num_threads,
       ].freeze
 
       attr_accessor(*KEYS)
@@ -19,6 +19,7 @@ class Fluentd
       validates :database, presence: true
       validate :validate_capped
       validate :validate_collection
+      validates :buffer_path, presence: true, if: ->{ buffer_type == "file" }
 
       def validate_capped
         return true if capped.blank?
@@ -49,7 +50,7 @@ class Fluentd
 
       def advanced_options
         [
-          :capped, :capped_size, :capped_max, :buffer_type, :buffer_queue_limit, :buffer_chunk_limit,
+          :capped, :capped_size, :capped_max, :buffer_type, :buffer_path, :buffer_queue_limit, :buffer_chunk_limit,
           :flush_interval, :retry_wait, :retry_limit, :max_retry_wait, :num_threads,
         ]
       end

--- a/app/models/fluentd/setting/out_s3.rb
+++ b/app/models/fluentd/setting/out_s3.rb
@@ -10,7 +10,7 @@ class Fluentd
         # :reduced_redundancy, :check_apikey_on_start, :command_parameter, # not configurable?
         :format, :include_time_key, :time_key, :delimiter, :label_delimiter, :add_newline, :output_tag, :output_time,
         :time_slice_format, :time_slice_wait, :time_format, :utc, :store_as, :proxy_uri, :use_ssl,
-        :buffer_type, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,
+        :buffer_type, :buffer_path, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,
         :retry_wait, :retry_limit, :max_retry_wait, :num_threads,
       ].freeze
 
@@ -24,6 +24,7 @@ class Fluentd
 
       validates :match, presence: true
       validates :s3_bucket, presence: true
+      validates :buffer_path, presence: true, if: ->{ buffer_type == "file" }
 
       def self.initial_params
         {
@@ -45,7 +46,7 @@ class Fluentd
         [
           :format, :output_tag, :output_time, :include_time_key, :time_key, :delimiter, :label_delimiter,
           :utc, :time_slice_format, :time_slice_wait, :store_as, :proxy_uri,
-          :buffer_type, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,
+          :buffer_type, :buffer_path, :buffer_queue_limit, :buffer_chunk_limit, :flush_interval,
           :retry_wait, :retry_limit, :max_retry_wait, :num_threads,
         ]
       end

--- a/app/models/fluentd/setting/out_td.rb
+++ b/app/models/fluentd/setting/out_td.rb
@@ -17,6 +17,7 @@ class Fluentd
       validates :match, presence: true
       validates :apikey, presence: true
       validates :auto_create_table, presence: true
+      validates :buffer_path, presence: true, if: ->{ buffer_type == "file" }
 
       def plugin_name
         "tdlog"


### PR DESCRIPTION
Display error message if `buffer_type` choice `file` and `buffer_path` is blank on configuration flow.