### PR TITLE
fix broken string-interpolation in append_and_remove_links()

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -54,8 +54,8 @@ module SettingsHelper
   end
 
   def append_and_remove_links
-    %Q!<a class="btn btn-xs btn-default js-append">icon('fa-plus')}</a> ! +
-    %Q!<a class="btn btn-xs btn-default js-remove" style="display:none">icon('fa-minus')}</a> !
+    %Q!<a class="btn btn-xs btn-default js-append">#{icon('fa-plus')}</a> ! +
+    %Q!<a class="btn btn-xs btn-default js-remove" style="display:none">#{icon('fa-minus')}</a> !
   end
 
   def child_data(form, key)


### PR DESCRIPTION
String-interpolation is broken in `append_and_remove_links()`.
Plus/Minus icons are displayed like: `icon('fa-plus')}`, not the Plus/Minus signs.
This affects for URL path: daemon/setting/out_forward.
