### PR TITLE
Apply bootstrap inputbox design to ones in login form

### DIFF
--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -6,8 +6,8 @@
     = render partial: "shared/error"
     = form_for(:session, url: sessions_path) do |f|
       .form-group
-        = f.text_field :name, placeholder: t('terms.name')
+        = f.text_field :name, placeholder: t('terms.name'), class: "form-control"
       .form-group
-        = f.password_field :password, placeholder: t('terms.password')
+        = f.password_field :password, placeholder: t('terms.password'), class: "form-control"
 
       = submit_tag t("terms.sign_in"), class: "btn btn-success"


### PR DESCRIPTION
I apply "form-control" class to inputbox in login page.

Before:

![before](https://cloud.githubusercontent.com/assets/594134/6936424/17c9ff14-d88d-11e4-94d6-23f03ce7f83b.png)

After:

![after](https://cloud.githubusercontent.com/assets/594134/6936425/1be1940e-d88d-11e4-8603-45986f05b168.png)
