### PR TITLE
Fix configtest/update behaviors are mismatched

### DIFF
--- a/app/controllers/fluentd/settings_controller.rb
+++ b/app/controllers/fluentd/settings_controller.rb
@@ -38,7 +38,7 @@ class Fluentd::SettingsController < ApplicationController
   def handle_dryrun
     if dryrun(params[:config])
       begin
-        parse_test(params[:config])
+        parse_config(params[:config])
         flash.now[:success] = I18n.t('messages.dryrun_is_passed')
       rescue Fluent::ConfigParseError => e
         flash.now[:danger] = e.message
@@ -51,6 +51,7 @@ class Fluentd::SettingsController < ApplicationController
   end
 
   def handle_update
+    parse_config(params[:config])
     update_config(params[:config])
     redirect_to daemon_setting_path(@fluentd)
   rescue Fluent::ConfigParseError => e
@@ -66,12 +67,12 @@ class Fluentd::SettingsController < ApplicationController
     @fluentd.agent.dryrun(tmpfile.path)
   end
 
-  def parse_test(conf)
-    Fluent::Config::V1Parser.parse(params[:config], @fluentd.config_file)
+  def parse_config(conf)
+    # V1Parser.parse could raise exception
+    Fluent::Config::V1Parser.parse(conf, @fluentd.config_file)
   end
 
   def update_config(conf)
-    Fluent::Config::V1Parser.parse(conf, @fluentd.config_file)
     @fluentd.agent.config_write conf
     @fluentd.agent.restart if @fluentd.agent.running?
   end

--- a/app/controllers/fluentd/settings_controller.rb
+++ b/app/controllers/fluentd/settings_controller.rb
@@ -69,7 +69,7 @@ class Fluentd::SettingsController < ApplicationController
 
   def parse_config(conf)
     # V1Parser.parse could raise exception
-    Fluent::Config::V1Parser.parse(conf, @fluentd.config_file)
+    Fluent::Config::V1Parser.parse(conf, @fluentd.config_file, File.dirname(@fluentd.config_file), binding)
   end
 
   def update_config(conf)

--- a/spec/features/setting_spec.rb
+++ b/spec/features/setting_spec.rb
@@ -47,4 +47,48 @@ describe 'setting', stub: :daemon do
     current_path.should == '/daemon/setting'
     page.should have_css('pre', text: 'YET ANOTHER CONFIG')
   end
+
+  describe "config test" do
+    before do
+      daemon.agent.config_write conf
+      click_link I18n.t('terms.edit')
+    end
+
+    context "plain config" do
+      let(:conf) { <<-'CONF' }
+      <source>
+        type forward
+      </source>
+      CONF
+
+      it 'configtest' do
+        click_button I18n.t('terms.configtest')
+        page.should have_css('.alert-success')
+      end
+
+      it "update & restart check" do
+        click_button I18n.t('terms.update')
+        daemon.agent.config.gsub("\r\n", "\n").should == conf # CodeMirror exchange \n -> \r\n
+      end
+    end
+
+    context "embedded config" do
+      let(:conf) { <<-'CONF' }
+      <source>
+        type forward
+        id "foo#{Time.now.to_s}"
+      </source>
+      CONF
+
+      it 'configtest' do
+        click_button I18n.t('terms.configtest')
+        page.should have_css('.alert-danger')
+      end
+
+      it "update & restart check" do
+        click_button I18n.t('terms.update')
+        page.should have_css('.alert-danger')
+      end
+    end
+  end
 end

--- a/spec/features/setting_spec.rb
+++ b/spec/features/setting_spec.rb
@@ -82,12 +82,12 @@ describe 'setting', stub: :daemon do
 
       it 'configtest' do
         click_button I18n.t('terms.configtest')
-        page.should have_css('.alert-danger')
+        page.should have_css('.alert-success')
       end
 
       it "update & restart check" do
         click_button I18n.t('terms.update')
-        page.should have_css('.alert-danger')
+        daemon.agent.config.gsub("\r\n", "\n").should == conf # CodeMirror exchange \n -> \r\n
       end
     end
   end

--- a/spec/features/setting_spec.rb
+++ b/spec/features/setting_spec.rb
@@ -48,7 +48,7 @@ describe 'setting', stub: :daemon do
     page.should have_css('pre', text: 'YET ANOTHER CONFIG')
   end
 
-  describe "config test" do
+  describe "config" do
     before do
       daemon.agent.config_write conf
       click_link I18n.t('terms.edit')


### PR DESCRIPTION
```
<source>
  type forward
  id "foo#{Time.now.to_s}"
</source>
```

like this config, configtest was passed, but Update & Restart was failed.

This PR fixes that behavior (should be success).