### PR TITLE
Remove rspec-its gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ group :development do
 end
 
 group :test do
-  gem "rspec-its"
   gem "factory_girl_rails"
   gem "database_cleaner", "~> 1.2.0"
   gem "capybara", "~> 2.4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,9 +207,6 @@ GEM
     rspec-expectations (3.2.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
-    rspec-its (1.2.0)
-      rspec-core (>= 3.0.0)
-      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
@@ -286,7 +283,6 @@ DEPENDENCIES
   pry
   pry-rails
   rake
-  rspec-its
   rspec-rails (~> 3.0)
   simplecov (~> 0.7.1)
   timecop

--- a/spec/models/fluentd/agent/common_spec.rb
+++ b/spec/models/fluentd/agent/common_spec.rb
@@ -13,21 +13,27 @@ describe 'Fluentd::Agent::Common' do
 
   describe '#pid' do
     context 'no pid file exists' do
-      its(:pid) { should be_nil }
+      it "should be nil" do
+        expect(subject.pid).to be_nil
+      end
     end
 
     context 'empty pid file given' do
       before { FileUtils.touch pid_file_path }
       after  { FileUtils.rm pid_file_path }
 
-      its(:pid) { should be_nil }
+      it "should be nil" do
+        expect(subject.pid).to be_nil
+      end
     end
 
     context 'valid pid file given' do
       before { File.write pid_file_path, '9999' }
       after  { FileUtils.rm pid_file_path }
 
-      its(:pid) { should eq(9999) }
+      it "should be 9999" do
+        expect(subject.pid).to eq(9999)
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ end
 ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../../config/environment", __FILE__)
 require 'rspec/rails'
-require 'rspec/its'
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
 require 'capybara/poltergeist'


### PR DESCRIPTION
I found rspec `its` syntax is used in few specs, so I revised them without `its`. After I removed this gem from dependencies.