### PR TITLE
Fix changing password without confirmation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :find_user
+  before_action :set_user
 
   def show
   end
@@ -14,7 +14,7 @@ class UsersController < ApplicationController
 
   private
 
-  def find_user
+  def set_user
     @user = User.new(name: session[:user_name])
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,7 @@ class User
   end
 
   def valid_password_confirmation
-    unless password == password_confirmation
+    if password != password_confirmation
       errors.add(:password, :confirmation, attribute: User.human_attribute_name(:password_confirmation))
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,9 @@ class User
   end
 
   def valid_password_confirmation
-    password == password_confirmation
+    unless password == password_confirmation
+      errors.add(:current_password, :wrong_password)
+    end
   end
 
   def stretching_cost

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User
 
   def valid_password_confirmation
     unless password == password_confirmation
-      errors.add(:current_password, :wrong_password)
+      errors.add(:password, :confirmation, attribute: User.human_attribute_name(:password_confirmation))
     end
   end
 

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -43,7 +43,7 @@ describe "sessions" do
 
     after do
       # reset password to the default
-      FileUtils.rm_rf(User::ENCRYPTED_PASSWORD_FILE)
+      FileUtils.rm_f(User::ENCRYPTED_PASSWORD_FILE)
     end
 
     context "correct password" do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -19,11 +19,12 @@ describe "users" do
     end
 
     describe 'to change password' do
+      let(:current_password) { user.password }
       let(:password) { 'new_password' }
 
       before do
         visit user_path
-        fill_in 'user[current_password]', with: user.password
+        fill_in 'user[current_password]', with: current_password
 
         fill_in 'user[password]', with: password
         fill_in 'user[password_confirmation]', with: password_confirmation
@@ -35,6 +36,7 @@ describe "users" do
 
         it 'should update users password with new password' do
           expect(page).to have_css('.alert-success')
+          expect(user.stored_digest).to eq user.digest(password)
         end
       end
 
@@ -43,6 +45,7 @@ describe "users" do
 
         it 'should not update users password with new password' do
           expect(page).to have_css('.alert-danger')
+          expect(user.stored_digest).to eq user.digest(current_password)
         end
       end
     end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe "users" do
-  describe "unlogined" do
+  describe "visit edit page before login" do
     let(:url) { user_path }
     it_should_behave_like "login required"
   end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -27,7 +27,7 @@ describe "users" do
 
         fill_in 'user[password]', with: password
         fill_in 'user[password_confirmation]', with: password_confirmation
-        find('input[type="submit"]').click
+        click_button I18n.t("terms.update_password")
       end
 
       context 'when valid new password/confirmation is input' do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -7,5 +7,44 @@ describe "users" do
   end
 
   describe "edit" do
+    let!(:user) { build(:user) }
+
+    before do
+      login_with user
+    end
+
+    after do
+      # reset password to the default
+      FileUtils.rm_rf(User::ENCRYPTED_PASSWORD_FILE)
+    end
+
+    describe 'to change password' do
+      let(:password) { 'new_password' }
+
+      before do
+        visit user_path
+        fill_in 'user[current_password]', with: user.password
+
+        fill_in 'user[password]', with: password
+        fill_in 'user[password_confirmation]', with: password_confirmation
+        find('input[type="submit"]').click
+      end
+
+      context 'when valid new password/confirmation is input' do
+        let(:password_confirmation) { password }
+
+        it 'should update users password with new password' do
+          expect(page).to have_css('.alert-success')
+        end
+      end
+
+      context 'when invalid new password/confirmation is input' do
+        let(:password_confirmation) { 'invalid_password' }
+
+        it 'should not update users password with new password' do
+          expect(page).to have_css('.alert-danger')
+        end
+      end
+    end
   end
 end

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -15,7 +15,7 @@ describe "users" do
 
     after do
       # reset password to the default
-      FileUtils.rm_rf(User::ENCRYPTED_PASSWORD_FILE)
+      FileUtils.rm_f(User::ENCRYPTED_PASSWORD_FILE)
     end
 
     describe 'to change password' do

--- a/spec/features/users_spec.rb
+++ b/spec/features/users_spec.rb
@@ -1,9 +1,11 @@
 require "spec_helper"
 
 describe "users" do
-  describe "edit" do
+  describe "unlogined" do
     let(:url) { user_path }
     it_should_behave_like "login required"
   end
 
+  describe "edit" do
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,8 +6,9 @@ describe User do
   describe "#valid?" do
     describe "password" do
       it "password != password_confirmation is invalid" do
-        user.password = "a"
-        user.password_confirmation = "b"
+        user.current_password = user.password
+        user.password = "aaaaaaaa"
+        user.password_confirmation = "bbbbbbbb"
         user.should_not be_valid
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,8 @@ describe User do
   let(:user) { build(:user) }
 
   describe "#valid?" do
+    subject { user.valid? }
+
     describe "password" do
       before do
         user.current_password = current_password
@@ -16,9 +18,7 @@ describe User do
         let(:password) { 'aaaaaaaa' }
         let(:password_confirmation) { 'bbbbbbbb' }
 
-        it 'should be false' do
-          user.should_not be_valid
-        end
+        it { should be_falsey }
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,10 +13,35 @@ describe User do
         user.password_confirmation = password_confirmation
       end
 
-      context 'when password != password_confirmation' do
+      context 'when current_password is correct' do
         let(:current_password) { user.password }
+
+        context 'when password/confirmation is 8 characters' do
+          let(:password) { 'aaaaaaaa' }
+          let(:password_confirmation) { password }
+
+          it { should be_truthy }
+        end
+
+        context 'when password is 7 characters' do
+          let(:password) { 'aaaaaaa' }
+          let(:password_confirmation) { password }
+
+          it { should be_falsey }
+        end
+
+        context 'when password != password_confirmation' do
+          let(:password) { 'aaaaaaaa' }
+          let(:password_confirmation) { 'bbbbbbbb' }
+
+          it { should be_falsey }
+        end
+      end
+
+      context 'when current_password is wrong' do
+        let(:current_password) { 'invalid_password' }
         let(:password) { 'aaaaaaaa' }
-        let(:password_confirmation) { 'bbbbbbbb' }
+        let(:password_confirmation) { password }
 
         it { should be_falsey }
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,22 +17,22 @@ describe User do
         let(:current_password) { user.password }
 
         context 'when password/confirmation is 8 characters' do
-          let(:password) { 'aaaaaaaa' }
+          let(:password) { 'a' * 8 }
           let(:password_confirmation) { password }
 
           it { should be_truthy }
         end
 
         context 'when password is 7 characters' do
-          let(:password) { 'aaaaaaa' }
+          let(:password) { 'a' * 7 }
           let(:password_confirmation) { password }
 
           it { should be_falsey }
         end
 
         context 'when password != password_confirmation' do
-          let(:password) { 'aaaaaaaa' }
-          let(:password_confirmation) { 'bbbbbbbb' }
+          let(:password) { 'a' * 8 }
+          let(:password_confirmation) { 'b' * 8 }
 
           it { should be_falsey }
         end
@@ -40,7 +40,7 @@ describe User do
 
       context 'when current_password is wrong' do
         let(:current_password) { 'invalid_password' }
-        let(:password) { 'aaaaaaaa' }
+        let(:password) { 'a' * 8 }
         let(:password_confirmation) { password }
 
         it { should be_falsey }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -27,14 +27,20 @@ describe User do
           let(:password) { 'a' * 7 }
           let(:password_confirmation) { password }
 
-          it { should be_falsey }
+          it 'should return false' do
+            should be_falsey
+            user.errors.keys.should == [:password]
+          end
         end
 
         context 'when password != password_confirmation' do
           let(:password) { 'a' * 8 }
           let(:password_confirmation) { 'b' * 8 }
 
-          it { should be_falsey }
+          it 'should return false' do
+            should be_falsey
+            user.errors.keys.should == [:password]
+          end
         end
       end
 
@@ -43,7 +49,10 @@ describe User do
         let(:password) { 'a' * 8 }
         let(:password_confirmation) { password }
 
-        it { should be_falsey }
+        it 'should return false' do
+          should be_falsey
+          user.errors.keys.should == [:current_password]
+        end
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,11 +5,20 @@ describe User do
 
   describe "#valid?" do
     describe "password" do
-      it "password != password_confirmation is invalid" do
-        user.current_password = user.password
-        user.password = "aaaaaaaa"
-        user.password_confirmation = "bbbbbbbb"
-        user.should_not be_valid
+      before do
+        user.current_password = current_password
+        user.password = password
+        user.password_confirmation = password_confirmation
+      end
+
+      context 'when password != password_confirmation' do
+        let(:current_password) { user.password }
+        let(:password) { 'aaaaaaaa' }
+        let(:password_confirmation) { 'bbbbbbbb' }
+
+        it 'should be false' do
+          user.should_not be_valid
+        end
       end
     end
   end


### PR DESCRIPTION
Now, password can be changed unexpectedly even if password doesn't match password\_confirmation. I fixed this bug and add specs.

The spec for `User#valid?` with invalid password\_confirmation exists before, but this spec passed by other validations ( `current_user is wrong` and `password is too short`).