### PR TITLE
Add `--host` option

### DIFF
--- a/lib/fluentd-ui/command.rb
+++ b/lib/fluentd-ui/command.rb
@@ -10,13 +10,14 @@ module FluentdUI
     option :port, type: :numeric, default: 9292
     option :pidfile, type: :string, default: File.expand_path('tmp/fluentd-ui.pid', ROOT)
     option :daemonize, type: :boolean, default: false
+    option :host, type: :string, default: 'localhost'
     def start
       trap(:INT) { puts "\nStopping..." }
       # NOTE: on Debian based distributions, td-agent uses start-stop-daemon with --exec option for stopping process
       #       then fluentd-ui will be killed by them because given --exec option matches.
       #       FLUENTD_UI_EXEC_COMMAND is used for workaround it.
       cmd = ENV['FLUENTD_UI_EXEC_COMMAND'].presence || "rackup"
-      system(* %w(bundle exec) + cmd.split(" ") + %W(#{options[:daemonize] ? "-D" : ""} --pid #{options[:pidfile]} -p #{options[:port]} -E production #{ROOT}/config.ru))
+      system(* %w(bundle exec) + cmd.split(" ") + %W(#{options[:daemonize] ? "-D" : ""} --pid #{options[:pidfile]} -p #{options[:port]} --host #{options[:host]} -E production #{ROOT}/config.ru))
     end
 
 

--- a/lib/fluentd-ui/command.rb
+++ b/lib/fluentd-ui/command.rb
@@ -10,7 +10,7 @@ module FluentdUI
     option :port, type: :numeric, default: 9292
     option :pidfile, type: :string, default: File.expand_path('tmp/fluentd-ui.pid', ROOT)
     option :daemonize, type: :boolean, default: false
-    option :host, type: :string, default: 'localhost'
+    option :host, type: :string, default: '0.0.0.0'
     def start
       trap(:INT) { puts "\nStopping..." }
       # NOTE: on Debian based distributions, td-agent uses start-stop-daemon with --exec option for stopping process


### PR DESCRIPTION
refs #176 

I added `--host` option to `start` command.

The `rackup` command runs in the back of `start` command binds `localhost` as default on https://github.com/rack/rack/pull/514 . This option enables to change this.

**edited**: I changed default host to `0.0.0.0` from `localhost` for backward compatibility.

```
$ ./bin/fluentd-ui start
Puma 2.11.1 starting...
* Min threads: 0, max threads: 16
* Environment: production
* Listening on tcp://0.0.0.0:9292
```

```
$ ./bin/fluentd-ui start --host localhost
Puma 2.11.1 starting...
* Min threads: 0, max threads: 16
* Environment: production
* Listening on tcp://localhost:9292
```