### PR TITLE
Clarify namespace even under Fluentd namespace

### DIFF
--- a/app/controllers/fluentd/settings_controller.rb
+++ b/app/controllers/fluentd/settings_controller.rb
@@ -6,7 +6,7 @@ class Fluentd::SettingsController < ApplicationController
   before_action :set_config, only: [:show, :edit, :update]
 
   def show
-    @backup_files = @fluentd.agent.backup_files_in_new_order.first(Settings.histories_count_in_preview).map do |file_path|
+    @backup_files = @fluentd.agent.backup_files_in_new_order.first(::Settings.histories_count_in_preview).map do |file_path|
       Fluentd::SettingArchive::BackupFile.new(file_path)
     end
 


### PR DESCRIPTION
`Fluentd::Settings` module also exists, so sometime solving namespace failed (e.g. fluentd-ui server shut down still dashboard page is opened, so server restart and "Config file" menu in its page is clicked, raise error.)