### PR TITLE
Use ruby2.1.3 in CircleCI (for v0.4.0)

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,5 +11,5 @@ checkout:
 
 dependencies:
   pre:
-    - wget http://packages.treasuredata.com.s3.amazonaws.com/2/ubuntu/precise/pool/contrib/t/td-agent/td-agent_2.1.3-0_amd64.deb
-    - sudo dpkg -i td-agent_2.1.3-0_amd64.deb
+    - wget http://packages.treasuredata.com.s3.amazonaws.com/2/ubuntu/precise/pool/contrib/t/td-agent/td-agent_2.2.0-0_amd64.deb
+    - sudo dpkg -i td-agent_2.2.0-0_amd64.deb

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   environment:
     SPEC_OPTS: "-f d --color"
+  ruby:
+    version: 2.1.3
 
 checkout:
   post:


### PR DESCRIPTION
I want to use Ruby > 2.1.3 (matched with `td-agent2`), but CIrcleCI uses ruby 1.9.3 as default.

In additon, I want to use the latest `td-agent` in CircleCI.