### PR TITLE
Use Config::Element instead of raw Hash

### DIFF
--- a/lib/regexp_preview/single_line.rb
+++ b/lib/regexp_preview/single_line.rb
@@ -18,7 +18,7 @@ module RegexpPreview
       else # apache, nginx, etc
         definition = Fluent::TextParser::TEMPLATE_REGISTRY.lookup(format).call
         raise "Unknown format '#{format}'" unless definition
-        definition.configure({}) # NOTE: SyslogParser define @regexp in configure method so call it to grab Regexp object
+        definition.configure(Fluent::Config::Element.new('ROOT', '', {}, [])) # NOTE: SyslogParser define @regexp in configure method so call it to grab Regexp object
         @regexp = definition.patterns["format"]
         @time_format = definition.patterns["time_format"]
       end


### PR DESCRIPTION
Fluentd raises an exception for raw Hash in newer versions.