### PR TITLE
boundio service migrated to twilio

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -180,7 +180,7 @@ defaults: &defaults
     - category: search
       name: "splunkapi"
     - category: notification
-      name: "boundio"
+      name: "twilio"
     - category: notification
       name: "growl"
 


### PR DESCRIPTION
Hi. Boundio has shutdown and migrated to Twilio for now.
https://www.facebook.com/TwilioforKWC/posts/524150507622893