### PR TITLE
Growl migrated terminal-notifier

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -182,7 +182,7 @@ defaults: &defaults
     - category: notification
       name: "twilio"
     - category: notification
-      name: "growl"
+      name: "terminal_notifier"
 
 development:
   <<: *defaults


### PR DESCRIPTION
Because Growl does not work with OS X 10.10 or later.