### PR TITLE
Suppress deprecation warning

### DIFF
--- a/spec/controllers/polling_controller_spec.rb
+++ b/spec/controllers/polling_controller_spec.rb
@@ -7,7 +7,7 @@ describe PollingController do
     end
 
     after do
-      response.should be_success
+      response.should be_successful
     end
 
     it 'may find nothing' do


### PR DESCRIPTION
> DEPRECATION WARNING: The success? predicate is deprecated and will
> be removed in Rails 6.0. Please use successful? as provided by
> Rack::Response::Helpers.

Signed-off-by: Kenji Okimoto <okimoto@clear-code.com>