### PR TITLE
Stop overwriting parameter type by `nil`

### DIFF
--- a/app/models/concerns/fluentd/setting/plugin.rb
+++ b/app/models/concerns/fluentd/setting/plugin.rb
@@ -52,7 +52,7 @@ class Fluentd
                   attribute("#{param_name}_type", :string)
                 end
               else
-                config_param(param_name, definition[:type], **definition.except(:type))
+                config_param(param_name, definition[:type] || self._types[param_name], **definition.except(:type))
               end
             end
           end


### PR DESCRIPTION
In such case, use value set by super class.

Close #277 