### PR TITLE
Use latest webmock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :test do
   gem "capybara-screenshot"
   gem "webdrivers"
   gem "simplecov", "~> 0.16.1", require: false
-  gem "webmock", "~> 3.3.0"
+  gem "webmock", "~> 3.12.2"
   gem "timecop"
   gem "selenium-webdriver", "~> 3.13.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,8 +124,8 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     cool.io (1.7.1)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
@@ -194,7 +194,7 @@ GEM
       haml (>= 4.0.6, < 6.0)
       html2haml (>= 1.0.1)
       railties (>= 4.0.1)
-    hashdiff (0.3.7)
+    hashdiff (1.0.1)
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -294,7 +294,6 @@ GEM
     ruby_parser (3.14.2)
       sexp_processor (~> 4.9)
     rubyzip (1.3.0)
-    safe_yaml (1.0.4)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -370,10 +369,10 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (>= 3.0, < 4.0)
-    webmock (3.3.0)
+    webmock (3.12.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (4.2.2)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
@@ -407,7 +406,7 @@ DEPENDENCIES
   timecop
   web-console (~> 3.6)
   webdrivers
-  webmock (~> 3.3.0)
+  webmock (~> 3.12.2)
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
It is required to support recent Ruby.

NOTE:

* Ruby 2.6: Webmock 3.5.0 or later
* Ruby 2.7: Webmock 3.8.0 or later

Ruby 2.4 support was dropped since Webmock 3.9.0
