### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
 
 rvm:
   - 2.5.1
-  - 2.4.4
 
 before_install:
   - google-chrome-stable --version


### PR DESCRIPTION
As Ruby 2.4 had already reached EOL

TODO: migrate Travis CI to GitHub Actions as a next step
