### PR TITLE
Upgrade to datatables.net-bs4

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "bootstrap": "^4.5.0",
     "bootstrap-vue": "^2.0.0-rc.14",
     "codemirror": "^5.37.0",
+    "datatables.net-bs4": "1.10.24",
     "es6-promise": "^4.2.4",
     "jquery": "^3.5.0",
     "lodash": "^4.17.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,10 +2614,25 @@ datatables.net-bs4@1.10.19:
     datatables.net "1.10.19"
     jquery ">=1.7"
 
+datatables.net-bs4@1.10.24:
+  version "1.10.24"
+  resolved "https://registry.yarnpkg.com/datatables.net-bs4/-/datatables.net-bs4-1.10.24.tgz#4b2ca1717e6dc06fd5b53a20015151f381473eb3"
+  integrity sha512-NgjQMqCo5pg49c5TWsc78UYhcvWPAFkZ7qH4yKAb1e0eLNCAo+TLeaIsDiAPpcWwP7xpjdAmZIIbXDpspNTCkg==
+  dependencies:
+    datatables.net "1.10.24"
+    jquery ">=1.7"
+
 datatables.net@1.10.19:
   version "1.10.19"
   resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.19.tgz#97a1ed41c85e62d61040603481b59790a172dd1f"
   integrity sha512-+ljXcI6Pj3PTGy5pesp3E5Dr3x3AV45EZe0o1r0gKENN2gafBKXodVnk2ypKwl2tTmivjxbkiqoWnipTefyBTA==
+  dependencies:
+    jquery ">=1.7"
+
+datatables.net@1.10.24:
+  version "1.10.24"
+  resolved "https://registry.yarnpkg.com/datatables.net/-/datatables.net-1.10.24.tgz#370e02f1e201de8334fdc92e7515c1624191573c"
+  integrity sha512-CwXixvOdinvBCLXvcTloDinWiEM7Geaz+GwyjPrZL+MXIGPcLv4Op1bbWn8ErsI1JWMIWC8Cuf1rnDU2RrFV5w==
   dependencies:
     jquery ">=1.7"
 


### PR DESCRIPTION
$ yarn upgrade datatables.net-bs4@1.10.24

The vulnerable version of datatables.net 1.10.19 is not used anymore.
(datatables.net-bs4 depends on datatables.net 1.10.19)
