### PR TITLE
Fix: Update broken links for td-agent (EOL) and ChromeDriver in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Gem Version](https://badge.fury.io/rb/fluentd-ui.svg)](http://badge.fury.io/rb/fluentd-ui)
 [![Code Climate](https://codeclimate.com/github/fluent/fluentd-ui/badges/gpa.svg)](https://codeclimate.com/github/fluent/fluentd-ui)
 
-fluentd-ui is a browser-based [fluentd](http://www.fluentd.org) and [td-agent](https://docs.treasuredata.com/articles/td-agent) manager that supports following operations.
+fluentd-ui is a browser-based [fluentd](http://www.fluentd.org) and [td-agent](https://www.fluentd.org/download/fluent_package) manager that supports following operations.
 
 * Install, uninstall, and upgrade Fluentd plugins
 * start/stop/restart fluentd process
@@ -81,7 +81,7 @@ Access http://localhost:3000 by web browser.
 
 ### Run tests
 
-You need [chromedriver](https://sites.google.com/a/chromium.org/chromedriver/downloads) or chromiumdriver to run tests.
+You need [chromedriver](https://chromedriver.chromium.org/downloads) or chromiumdriver to run tests.
 
     $ npm install -g chromedriver
     Or,


### PR DESCRIPTION


## PR Description

This PR updates two outdated/broken links in the README as reported in [\#457](https://github.com/fluent/fluentd-ui/issues/457):

- **td-agent:**
The previous link to td-agent is now obsolete, as td-agent reached End of Life in Dec 2023. The new link points to the [Fluent Package download page](https://www.fluentd.org/download/fluent_package), which is the official migration path for td-agent users and provides LTS releases and migration guidance.
- **ChromeDriver:**
The previous ChromeDriver download link was no longer accessible. It is now replaced with the official [ChromeDriver downloads page](https://chromedriver.chromium.org/downloads), which is current and maintained.


### Changes

- In the introduction, updated the td-agent link to:
`[td-agent](https://www.fluentd.org/download/fluent_package)`
- In the development/testing section, updated the ChromeDriver link to:
`[ChromeDriver official downloads page](https://chromedriver.chromium.org/downloads)`


Closes #457